### PR TITLE
fix: Symlink switcher

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -23,3 +23,4 @@ chmod +x "$ASDF_DOWNLOAD_PATH/kubeswitch"
 
 # create a relative symlink to the binary in the install directory
 ln -rsfn "$ASDF_DOWNLOAD_PATH/kubeswitch" "$ASDF_DOWNLOAD_PATH/switcher"
+ls -la "$ASDF_DOWNLOAD_PATH/switcher"

--- a/bin/download
+++ b/bin/download
@@ -20,7 +20,3 @@ mv "$release_file" "$ASDF_DOWNLOAD_PATH/kubeswitch"
 
 # Make the binary executable
 chmod +x "$ASDF_DOWNLOAD_PATH/kubeswitch"
-
-# create a relative symlink to the binary in the install directory
-ln -rsfn "$ASDF_DOWNLOAD_PATH/kubeswitch" "$ASDF_DOWNLOAD_PATH/switcher"
-ls -la "$ASDF_DOWNLOAD_PATH/switcher"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -94,10 +94,7 @@ install_version() {
 		tool_cmd2="$(echo "$TOOL_TEST2" | cut -d' ' -f1)"
 
 		# create a relative symlink to the binary in the install directory
-		ln -sfn "$install_path/$tool_cmd" "$install_path/$tool_cmd2"
-
-		ls -la "$install_path/"
-
+		ln -sfn "$install_path/$tool_cmd" "$install_path/$tool_cmd2" || fail "Could not create symlink $install_path/$tool_cmd2"
 		test -x "$install_path/$tool_cmd2" || fail "Expected $install_path/$tool_cmd2 to be executable."
 
 		echo "$TOOL_NAME2 $version installation was successful!"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -93,6 +93,8 @@ install_version() {
 		# create a relative symlink to the binary in the install directory
 		ln -sfn "$install_path/$tool_cmd" "$install_path/$TOOL_TEST2"
 
+		ls -la "$install_path/$TOOL_TEST2"
+
 		local tool_cmd2
 		tool_cmd2="$(echo "$TOOL_TEST2" | cut -d' ' -f1)"
 		test -x "$install_path/$tool_cmd2" || fail "Expected $install_path/$tool_cmd2 to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -90,13 +90,14 @@ install_version() {
 
 		echo "$TOOL_NAME $version installation was successful!"
 
-		# create a relative symlink to the binary in the install directory
-		ln -sfn "$install_path/$tool_cmd" "$install_path/$TOOL_TEST2"
-
-		ls -la "$install_path/$TOOL_TEST2"
-
 		local tool_cmd2
 		tool_cmd2="$(echo "$TOOL_TEST2" | cut -d' ' -f1)"
+
+		# create a relative symlink to the binary in the install directory
+		ln -sfn "$install_path/$tool_cmd" "$install_path/$tool_cmd2"
+
+		ls -la "$install_path/"
+
 		test -x "$install_path/$tool_cmd2" || fail "Expected $install_path/$tool_cmd2 to be executable."
 
 		echo "$TOOL_NAME2 $version installation was successful!"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -90,6 +90,9 @@ install_version() {
 
 		echo "$TOOL_NAME $version installation was successful!"
 
+		# create a relative symlink to the binary in the install directory
+		ln -sfn "$install_path/$tool_cmd" "$install_path/$TOOL_TEST2"
+
 		local tool_cmd2
 		tool_cmd2="$(echo "$TOOL_TEST2" | cut -d' ' -f1)"
 		test -x "$install_path/$tool_cmd2" || fail "Expected $install_path/$tool_cmd2 to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -5,6 +5,8 @@ set -euo pipefail
 GH_REPO="https://github.com/danielfoehrKn/kubeswitch"
 TOOL_NAME="kubeswitch"
 TOOL_TEST="kubeswitch -h"
+TOOL_NAME2="switcher"
+TOOL_TEST2="switcher -h"
 
 fail() {
 	echo -e "asdf-$TOOL_NAME: $*"
@@ -87,6 +89,12 @@ install_version() {
 		test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
 
 		echo "$TOOL_NAME $version installation was successful!"
+
+		local tool_cmd2
+		tool_cmd2="$(echo "$TOOL_TEST2" | cut -d' ' -f1)"
+		test -x "$install_path/$tool_cmd2" || fail "Expected $install_path/$tool_cmd2 to be executable."
+
+		echo "$TOOL_NAME2 $version installation was successful!"
 	) || (
 		rm -rf "$install_path"
 		fail "An error occurred while installing $TOOL_NAME $version."


### PR DESCRIPTION
The deployed name of the kubeswitch executable is 'switcher' rather than `kubeswitch`, and this assumption is baked into the integration scripts that kubeswitch provides. For this reason we symlink `kubeswitch` to `switcher`.

ASDF downloads releases to a separate directory and then copies them to the install path. MacOS doesn't use a version of the `ln` command that supports `--relative` for creating relative symlinks. Without this any symlinks created after download will be broken once copied to the install path.

We could work around this in the download script, or make the link in the install script, which is probably where it should have been anyway.